### PR TITLE
Feat: Implementation of the useIcon hook for Client Components

### DIFF
--- a/lib/Shared/useIcon.tsx
+++ b/lib/Shared/useIcon.tsx
@@ -1,0 +1,45 @@
+import { ComponentType } from 'react'
+import IconProps from '@/typings/Icon'
+import FolderIcon from '@/svgs/outline/FolderIcon'
+import BuildingStoreFrontIcon from '@/svgs/outline/BuildingStoreFrontIcon'
+import CursorArrowRaysIcon from '@/svgs/outline/CursorArrowRaysIcon'
+import ShoppingBagIcon from '@/svgs/outline/ShoppingBagIcon'
+import HomeIcon from '@/svgs/outline/HomeIcon'
+import AdjustmentsVerticalIcon from '@/svgs/outline/AdjustmentsVerticalIcon'
+import LockOpenIcon from '@/svgs/outline/LockOpenIcon'
+
+export interface useIconProps {
+  iconName: 'FolderIcon' | 'AdjustmentsVerticalIcon' | 'BuildingStoreFrontIcon' | 'CursorArrowRaysIcon' | 'HomeIcon' | 'ShoppingBagIcon' | 'LockOpenIcon' | undefined
+}
+
+export default function useIcon(iconName: useIconProps['iconName']) {
+  let Icon = (): ComponentType<IconProps> => {
+    switch (iconName) {
+      case 'FolderIcon':
+        return FolderIcon
+
+      case 'AdjustmentsVerticalIcon':
+        return AdjustmentsVerticalIcon
+
+      case 'HomeIcon':
+        return HomeIcon
+
+      case 'BuildingStoreFrontIcon':
+        return BuildingStoreFrontIcon
+
+      case 'CursorArrowRaysIcon':
+        return CursorArrowRaysIcon
+
+      case 'ShoppingBagIcon':
+        return ShoppingBagIcon
+
+      case 'LockOpenIcon':
+        return LockOpenIcon
+
+      default:
+        return () => null
+    }
+  }
+
+  return Icon()
+}

--- a/svgs/outline/AdjustmentsVerticalIcon.tsx
+++ b/svgs/outline/AdjustmentsVerticalIcon.tsx
@@ -1,0 +1,14 @@
+import { twMerge } from 'tailwind-merge'
+import IconProps from '@/typings/Icon'
+
+export default function AdjustmentsVerticalIcon({ className }: IconProps) {
+  return (
+    <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' strokeWidth={1.5} stroke='currentColor' className={twMerge('h-6 w-6', className)}>
+      <path
+        strokeLinecap='round'
+        strokeLinejoin='round'
+        d='M6 13.5V3.75m0 9.75a1.5 1.5 0 010 3m0-3a1.5 1.5 0 000 3m0 3.75V16.5m12-3V3.75m0 9.75a1.5 1.5 0 010 3m0-3a1.5 1.5 0 000 3m0 3.75V16.5m-6-9V3.75m0 3.75a1.5 1.5 0 010 3m0-3a1.5 1.5 0 000 3m0 9.75V10.5'
+      />
+    </svg>
+  )
+}

--- a/svgs/outline/BuildingStoreFrontIcon.tsx
+++ b/svgs/outline/BuildingStoreFrontIcon.tsx
@@ -1,0 +1,14 @@
+import { twMerge } from 'tailwind-merge'
+import IconProps from '@/typings/Icon'
+
+export default function BuildingStoreFrontIcon({ className }: IconProps) {
+  return (
+    <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' strokeWidth={1.5} stroke='currentColor' className={twMerge('h-6 w-6', className)}>
+      <path
+        strokeLinecap='round'
+        strokeLinejoin='round'
+        d='M13.5 21v-7.5a.75.75 0 01.75-.75h3a.75.75 0 01.75.75V21m-4.5 0H2.36m11.14 0H18m0 0h3.64m-1.39 0V9.349m-16.5 11.65V9.35m0 0a3.001 3.001 0 003.75-.615A2.993 2.993 0 009.75 9.75c.896 0 1.7-.393 2.25-1.016a2.993 2.993 0 002.25 1.016c.896 0 1.7-.393 2.25-1.016a3.001 3.001 0 003.75.614m-16.5 0a3.004 3.004 0 01-.621-4.72L4.318 3.44A1.5 1.5 0 015.378 3h13.243a1.5 1.5 0 011.06.44l1.19 1.189a3 3 0 01-.621 4.72m-13.5 8.65h3.75a.75.75 0 00.75-.75V13.5a.75.75 0 00-.75-.75H6.75a.75.75 0 00-.75.75v3.75c0 .415.336.75.75.75z'
+      />
+    </svg>
+  )
+}

--- a/svgs/outline/CursorArrowRaysIcon.tsx
+++ b/svgs/outline/CursorArrowRaysIcon.tsx
@@ -1,0 +1,14 @@
+import { twMerge } from 'tailwind-merge'
+import IconProps from '@/typings/Icon'
+
+export default function CursorArrowRaysIcon({ className }: IconProps) {
+  return (
+    <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' strokeWidth={1.5} stroke='currentColor' className={twMerge('h-6 w-6', className)}>
+      <path
+        strokeLinecap='round'
+        strokeLinejoin='round'
+        d='M15.042 21.672L13.684 16.6m0 0l-2.51 2.225.569-9.47 5.227 7.917-3.286-.672zM12 2.25V4.5m5.834.166l-1.591 1.591M20.25 10.5H18M7.757 14.743l-1.59 1.59M6 10.5H3.75m4.007-4.243l-1.59-1.59'
+      />
+    </svg>
+  )
+}

--- a/svgs/outline/FolderIcon.tsx
+++ b/svgs/outline/FolderIcon.tsx
@@ -1,0 +1,14 @@
+import { twMerge } from 'tailwind-merge'
+import IconProps from '@/typings/Icon'
+
+export default function FolderIcon({ className }: IconProps) {
+  return (
+    <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' strokeWidth={1.5} stroke='currentColor' className={twMerge('h-6 w-6', className)}>
+      <path
+        strokeLinecap='round'
+        strokeLinejoin='round'
+        d='M2.25 12.75V12A2.25 2.25 0 014.5 9.75h15A2.25 2.25 0 0121.75 12v.75m-8.69-6.44l-2.12-2.12a1.5 1.5 0 00-1.061-.44H4.5A2.25 2.25 0 002.25 6v12a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9a2.25 2.25 0 00-2.25-2.25h-5.379a1.5 1.5 0 01-1.06-.44z'
+      />
+    </svg>
+  )
+}

--- a/svgs/outline/HomeIcon.tsx
+++ b/svgs/outline/HomeIcon.tsx
@@ -1,0 +1,14 @@
+import { twMerge } from 'tailwind-merge'
+import IconProps from '@/typings/Icon'
+
+export default function HomeIcon({ className }: IconProps) {
+  return (
+    <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' strokeWidth={1.5} stroke='currentColor' className={twMerge('h-6 w-6', className)}>
+      <path
+        strokeLinecap='round'
+        strokeLinejoin='round'
+        d='M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25'
+      />
+    </svg>
+  )
+}

--- a/svgs/outline/LockOpenIcon.tsx
+++ b/svgs/outline/LockOpenIcon.tsx
@@ -1,0 +1,14 @@
+import IconProps from '@/typings/Icon'
+import { twMerge } from 'tailwind-merge'
+
+export default function LockOpenIcon({ className }: IconProps) {
+  return (
+    <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' strokeWidth={1.5} stroke='currentColor' className={twMerge('h-6 w-6', className)}>
+      <path
+        strokeLinecap='round'
+        strokeLinejoin='round'
+        d='M13.5 10.5V6.75a4.5 4.5 0 119 0v3.75M3.75 21.75h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H3.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z'
+      />
+    </svg>
+  )
+}

--- a/svgs/outline/ShoppingBagIcon.tsx
+++ b/svgs/outline/ShoppingBagIcon.tsx
@@ -1,0 +1,14 @@
+import { twMerge } from 'tailwind-merge'
+import IconProps from '@/typings/Icon'
+
+export default function ShoppingBagIcon({ className }: IconProps) {
+  return (
+    <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' strokeWidth={1.5} stroke='currentColor' className={twMerge('h-6 w-6', className)}>
+      <path
+        strokeLinecap='round'
+        strokeLinejoin='round'
+        d='M15.75 10.5V6a3.75 3.75 0 10-7.5 0v4.5m11.356-1.993l1.263 12c.07.665-.45 1.243-1.119 1.243H4.25a1.125 1.125 0 01-1.12-1.243l1.264-12A1.125 1.125 0 015.513 7.5h12.974c.576 0 1.059.435 1.119 1.007zM8.625 10.5a.375.375 0 11-.75 0 .375.375 0 01.75 0zm7.5 0a.375.375 0 11-.75 0 .375.375 0 01.75 0z'
+      />
+    </svg>
+  )
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,7 @@
       "@/typings/*": ["./typings/*"],
       "@/actions/*": ["./actions/*"],
       "@/public/*": ["./public/*"],
+      "@/svgs/*": ["./svgs/*"],
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],

--- a/typings/Icon.ts
+++ b/typings/Icon.ts
@@ -1,0 +1,3 @@
+export default interface IconProps {
+  className?: string
+}


### PR DESCRIPTION
This hook is a 'dirty' work around, for the issue of passing functions / components from a server component to a client component. Now instead of passing a function the icon's name is passed through. The client component then uses this hook to render the requested icon.

The following changes were made:
- created an `IconProps` interface that specifies the properties for each icon
- added multiple svg icons to the /svgs directory
- added `@/svgs` prefix to the tsconfig
- created useIcon hook