### PR TITLE
Refactor: Replaced Manual Connection String with .env variable

### DIFF
--- a/lib/Shared/Database.ts
+++ b/lib/Shared/Database.ts
@@ -1,12 +1,12 @@
 import { Db, MongoClient } from 'mongodb'
 
 async function connect() {
-  const { DATABASE_HOST, DATABASE_PORT, DATABASE_NAME } = process.env
-  if (!DATABASE_HOST || !DATABASE_PORT || !DATABASE_NAME) {
+  const { DATABASE_HOST, DATABASE_PORT, DATABASE_NAME, MONGODB_URI } = process.env
+  if (!DATABASE_HOST || !DATABASE_PORT || !DATABASE_NAME || !MONGODB_URI) {
     throw new Error('Missing Database Variables!')
   }
 
-  const client = new MongoClient(`mongodb://${DATABASE_HOST}:${DATABASE_PORT}`)
+  const client = new MongoClient(MONGODB_URI)
   await client.connect()
   return client.db(DATABASE_NAME)
 }


### PR DESCRIPTION
Replaced the manual composition of the mongodb-connection string with the already existing .env variable.

Now it is possible to easily authenticate to the database just by adapting the connection string that is stored in the enviroment variables.