### PR TITLE
Fix: Fixed Color-Mode Preference Determination

### DIFF
--- a/app/(components)/root/NavigationBar/ColorModeSwitcher.tsx
+++ b/app/(components)/root/NavigationBar/ColorModeSwitcher.tsx
@@ -36,7 +36,8 @@ export default function ColorModeSwitcher({ className }: { className?: string })
   }
 
   useEffect(() => {
-    const preference = parseCookies()?.colorMode ?? window?.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+    const preference = (parseCookies()?.colorMode ?? (window?.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')) as 'light' | 'dark'
+
     setMode(preference) //? Set the initial color-preference
     if (!parseCookies()?.colorMode) updateColorMode(preference, cookiePermission())
 


### PR DESCRIPTION
Previously the color-mode preference was always set to 'dark', when the color-mode cookie was set, due to missing brackets.