### PR TITLE
Feat: Drafted Page that shows the Available Bikes of a Station

### DIFF
--- a/app/(components)/Shared/Select.tsx
+++ b/app/(components)/Shared/Select.tsx
@@ -85,7 +85,7 @@ SelectComponent.Box = ({ placeHolder, className, dynamicTextClassName }: { dynam
       )}>
       <DynamicText
         content={selection?.length > 0 ? selection?.join(', ') : placeHolder}
-        className={twMerge('block flex-1 overflow-x-hidden truncate pr-6', dynamicTextClassName)}
+        className={twMerge('block flex-1 overflow-x-hidden truncate pr-6', dynamicTextClassName, selection.length === 0 ? 'text-gray-500 dark:text-gray-400' : '')}
         skContainerClassName='flex-1'
         isPending={isPending}
       />

--- a/app/(components)/stations/RenderParkingPlaces.tsx
+++ b/app/(components)/stations/RenderParkingPlaces.tsx
@@ -83,16 +83,15 @@ function RenderParkingPlace({ parkingPlace: { id, bike, allowedCategories } }: {
         </SelectComponent>
       </div>
 
-      {bike && (
-        <InputGroup
-          isPending={isPending}
-          name='parked bike'
-          data-result='string'
-          readOnly={true}
-          className='flex-1 rounded-md px-2 py-1 dark:bg-neutral-600/60 dark:text-gray-200'
-          defaultValue={bike._id}
-        />
-      )}
+      <InputGroup
+        key={id}
+        isPending={isPending}
+        name='Has Bike'
+        data-result='string'
+        readOnly={true}
+        className='flex-1 rounded-md px-2 py-1 focus:outline-none focus:ring-2 dark:bg-neutral-600/60 dark:text-gray-200 dark:focus:ring-blue-600/60'
+        defaultValue={bike?._id ?? 'No'}
+      />
     </div>
   )
 }

--- a/app/(components)/stations/RenderStation.tsx
+++ b/app/(components)/stations/RenderStation.tsx
@@ -11,6 +11,7 @@ import { DynamicText } from '@/app/(components)/Shared/Responsive/DynamicText'
 import Rating from '@/app/(components)/Shared/Rating'
 import ReactState from '@/typings/ReactState'
 import RenderParkingPlaces from '@/app/(components)/stations/RenderParkingPlaces'
+import Link from 'next/link'
 
 interface RenderStationContextProps {
   initialStation: WithId<Station>
@@ -71,22 +72,43 @@ export default function RenderStation({ station: initialStation, editable, isPen
           <RenderParkingPlaces />
         </div>
 
-        <form>
-          <ActionButtons />
+        <form className='flex justify-end gap-2 '>
+          <RegularActionButtons />
+          <ManagementActionButtons />
         </form>
       </div>
     </RenderStationContext.Provider>
   )
 }
 
-function ActionButtons() {
+function RegularActionButtons() {
+  const { station, isPending } = useContext(RenderStationContext)
+
+  if (isPending) {
+    return (
+      <div className='flex h-8 w-[120px] items-center justify-center gap-2 rounded-md bg-gray-800/50 px-2 py-1 capitalize tracking-wide text-gray-100 dark:bg-gray-400/50 dark:text-gray-200'>
+        <DynamicText content='' skeletonClassName='flex-1 dark:bg-gray-400' skWidth='w-24' isPending />
+      </div>
+    )
+  }
+
+  return (
+    <div className='flex justify-end gap-2'>
+      <Link href={`/stations/${station._id.toString()}/bikes`} className='rounded-md bg-gray-800/50 px-2 py-1 capitalize tracking-wide text-gray-100 dark:bg-gray-400/50 dark:text-gray-200'>
+        Check Available Bikes
+      </Link>
+    </div>
+  )
+}
+
+function ManagementActionButtons() {
   const { initialStation, station, isPending, editable: visible } = useContext(RenderStationContext)
 
   if (!visible) return null
 
   if (isPending) {
     return (
-      <div className='mt-4 flex h-8 justify-end gap-2'>
+      <div className='flex h-8 justify-end gap-2'>
         <div className='flex w-[80px] items-center justify-center rounded-md bg-blue-800/50 px-2 py-1 uppercase tracking-wide text-gray-100 dark:bg-blue-400/50 dark:text-gray-200'>
           <DynamicText content='' skeletonClassName='flex-1 dark:bg-gray-400' skWidth='w-14' isPending />
         </div>
@@ -99,7 +121,7 @@ function ActionButtons() {
   }
 
   return (
-    <div className='mt-4 flex justify-end gap-2'>
+    <div className='flex justify-end gap-2'>
       <button
         className='rounded-md bg-blue-800/50 px-2 py-1 uppercase tracking-wide text-gray-100 dark:bg-blue-400/50 dark:text-gray-200'
         formAction={() => UpdateStationAction(initialStation._id, station)}>

--- a/app/(components)/stations/book/RenderParkingPlaceTickets.tsx
+++ b/app/(components)/stations/book/RenderParkingPlaceTickets.tsx
@@ -1,0 +1,84 @@
+'use client'
+import { ParkingPlace } from '@/typings/Bike'
+import { useEffect, useState } from 'react'
+import Ticket from '@/typings/Ticket'
+import RenderBikeModel from '@/app/(components)/bikeModel/RenderBikeModel'
+import createTicket from '@/lib/tickets/TicketCalculation'
+
+export default function RenderParkingPlaceTickets({ parkingPlace }: { parkingPlace: ParkingPlace }) {
+  const defaultStart = new Date(Date.now())
+  const defaultEnd = new Date(Date.now())
+  defaultEnd.setHours(defaultEnd.getHours() + 1)
+
+  const [interval, setInterval] = useState<Ticket['interval']>({ start: defaultStart, end: defaultEnd })
+  const [ticket, setTicket] = useState<Ticket | undefined>(undefined)
+
+  useEffect(() => {
+    if (!interval) return setTicket(undefined)
+    if (!interval.start || !interval.end) return setTicket(undefined)
+
+    const ticket = createTicket(parkingPlace.bike!, interval.start, interval.end)
+    setTicket(ticket)
+  }, [interval])
+
+  return (
+    <div className='flex flex-col gap-2 rounded-md bg-neutral-200 px-4 py-2 dark:bg-neutral-700/40'>
+      <div className='flex flex-col gap-4 2sm:flex-row'>
+        <span className='font-semibold text-gray-700 dark:text-gray-200'>Parked at:</span>
+        <span>Parking-Place-{parkingPlace.id}</span>
+      </div>
+      <div className='flex flex-col gap-4 2sm:flex-row'>
+        <span className='font-semibold text-gray-700 dark:text-gray-200'>Model:</span>
+        <RenderBikeModel bikeModel={parkingPlace.bike!.model} />
+      </div>
+      <div className='mt-1 border-t border-dashed border-gray-700 pt-2 dark:border-gray-400'>
+        <span className='text-md font-semibold'>Ticket Pricing</span>
+        <div className='my-2 flex flex-col gap-2 md:flex-row'>
+          <div className='flex break-inside-avoid-column items-center gap-2'>
+            <span>Start:</span>
+            <input
+              onChange={(e) =>
+                setInterval((prev) => {
+                  if (!e.target.valueAsDate) return prev
+
+                  return { ...prev, start: e.target.valueAsDate }
+                })
+              }
+              type='datetime-local'
+              defaultValue={defaultStart.toISOString().split('.').at(0)}
+              className='px-1 py-0.5 text-sm focus:outline-none dark:bg-neutral-600/60'
+            />
+          </div>
+
+          <div className='flex break-inside-avoid-column items-center gap-2'>
+            <span>End:</span>
+            <input
+              onChange={(e) =>
+                setInterval((prev) => {
+                  if (!e.target.valueAsDate) return prev
+
+                  return { ...prev, start: e.target.valueAsDate }
+                })
+              }
+              type='datetime-local'
+              defaultValue={defaultEnd.toISOString().split('.').at(0)}
+              className='px-1 py-0.5 text-sm focus:outline-none dark:bg-neutral-600/60'
+            />
+          </div>
+        </div>
+        {ticket && (
+          <form className='flex justify-between'>
+            <div className='flex gap-2'>
+              <span className='font-semibold'>Trip Costs:</span>
+              <span>{ticket.price}€</span>
+            </div>
+
+            <button formAction={() => {}} className='mt-4 rounded-md bg-blue-800/50 px-2 py-1 uppercase tracking-wide text-gray-100 dark:bg-blue-400/50 dark:text-gray-200'>
+              Book Ticket
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/stations/[station_id]/bikes/page.tsx
+++ b/app/stations/[station_id]/bikes/page.tsx
@@ -1,0 +1,44 @@
+import { getStation } from '@/lib/station/StationDAO'
+import { notFound } from 'next/navigation'
+import RenderBikeModel from '@/app/(components)/bikeModel/RenderBikeModel'
+
+interface SearchParams {
+  params: {
+    station_id: string
+  }
+}
+
+export default async function StationBikesPage({ params: { station_id } }: SearchParams) {
+  const station = await getStation(station_id)
+  if (!station) notFound()
+
+  const usedParkingPlaces = station.address.parkingPlaces?.filter((pp) => !!pp.bike)
+  if (!usedParkingPlaces || usedParkingPlaces.length === 0) {
+    return (
+      <div>
+        <h1 className='mb-8 text-center text-3xl font-semibold lg:text-left'>Bikes of {station.name}</h1>
+        <div className='text-lg'>No bikes are available at this station.</div>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <h1 className='mb-8 text-center text-3xl font-semibold lg:text-left'>Bikes of {station.name}</h1>
+      <div className='flex gap-4'>
+        {usedParkingPlaces?.map((up) => (
+          <div key={up.id} className='flex flex-col gap-2 rounded-md px-4 py-2 dark:bg-neutral-700/40'>
+            <div className='flex flex-col gap-4 2sm:flex-row'>
+              <span className='font-semibold text-gray-700 dark:text-gray-200'>Parked at:</span>
+              <span>Parking-Place-{up.id}</span>
+            </div>
+            <div className='flex flex-col gap-4 2sm:flex-row'>
+              <span className='font-semibold text-gray-700 dark:text-gray-200'>Model:</span>
+              <RenderBikeModel bikeModel={up.bike!.model} />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/stations/[station_id]/bikes/page.tsx
+++ b/app/stations/[station_id]/bikes/page.tsx
@@ -1,6 +1,6 @@
 import { getStation } from '@/lib/station/StationDAO'
 import { notFound } from 'next/navigation'
-import RenderBikeModel from '@/app/(components)/bikeModel/RenderBikeModel'
+import RenderParkingPlaceTickets from '@/app/(components)/stations/book/RenderParkingPlaceTickets'
 
 interface SearchParams {
   params: {
@@ -25,20 +25,7 @@ export default async function StationBikesPage({ params: { station_id } }: Searc
   return (
     <div>
       <h1 className='mb-8 text-center text-3xl font-semibold lg:text-left'>Bikes of {station.name}</h1>
-      <div className='flex gap-4'>
-        {usedParkingPlaces?.map((up) => (
-          <div key={up.id} className='flex flex-col gap-2 rounded-md px-4 py-2 dark:bg-neutral-700/40'>
-            <div className='flex flex-col gap-4 2sm:flex-row'>
-              <span className='font-semibold text-gray-700 dark:text-gray-200'>Parked at:</span>
-              <span>Parking-Place-{up.id}</span>
-            </div>
-            <div className='flex flex-col gap-4 2sm:flex-row'>
-              <span className='font-semibold text-gray-700 dark:text-gray-200'>Model:</span>
-              <RenderBikeModel bikeModel={up.bike!.model} />
-            </div>
-          </div>
-        ))}
-      </div>
+      <div className='flex gap-4'>{usedParkingPlaces?.map((up) => <RenderParkingPlaceTickets key={up.id} parkingPlace={up} />)}</div>
     </div>
   )
 }

--- a/lib/station/StationDAO.ts
+++ b/lib/station/StationDAO.ts
@@ -35,3 +35,9 @@ export async function updateStation(id: string | ObjectId, update: WithId<Statio
   const collection = await getCollection(COLLECTION_STATIONS!)
   await collection.updateOne({ _id: new ObjectId(id.toString()) }, { $set: update })
 }
+
+export async function getStation(id: string) {
+  const collection = await getCollection(COLLECTION_STATIONS!)
+  const station = (await collection.findOne({ _id: new ObjectId(id) })) as WithId<Station> | null
+  return station
+}

--- a/lib/tickets/TicketCalculation.ts
+++ b/lib/tickets/TicketCalculation.ts
@@ -1,0 +1,40 @@
+import { Bike, BikeBreakType, BikeCategory } from '@/typings/Bike'
+
+export default function createTicket(bike: Bike, start: Date, end: Date) {
+  const price = parseFloat(((10 + getHoursRented(start, end) * 5) * getModelFactor(bike.model.category) * getBreaksFactor(bike.model.brakeType)).toFixed(2))
+
+  return {
+    interval: {
+      start,
+      end,
+    },
+    price,
+    bike,
+  }
+}
+
+function getModelFactor(model: BikeCategory['name']) {
+  switch (model) {
+    case 'Children':
+      return 1.05
+    case 'City':
+      return 1.1
+    case 'Mountain':
+      return 1.2
+    case 'Electric':
+      return 1.4
+  }
+}
+
+function getHoursRented(start: Date, end: Date) {
+  return Math.abs(start.getTime() - end.getTime()) / 36e5
+}
+
+function getBreaksFactor(breaks: BikeBreakType['name']) {
+  switch (breaks) {
+    case 'Frame':
+      return 1.02
+    case 'Disc':
+      return 1.05
+  }
+}

--- a/typings/Ticket.ts
+++ b/typings/Ticket.ts
@@ -1,0 +1,10 @@
+import { Bike } from '@/typings/Bike'
+
+export default interface Ticket {
+  bike: Bike
+  interval: {
+    start: Date
+    end: Date
+  }
+  price: number
+}


### PR DESCRIPTION
The following changes are made in this Pullrequest:
- updated InputGroup property in RenderParkingPlaces
   label is now 'Has Bike' instead of 'Parked Bike'
   value is now either 'No' or the Bike-id instead of bike-id or hidden InputGroup
- fixed Select-component place-holder color
- added `RegularAction` button to RenderStation-component
   This action-button redirects the user to the `/stations/[station_id]/bikes` page that shows the available bikes of a station.
- created `getStation` function in StationsDAO
- created Ticket-interface
- created `createTicket` function 
- created `/stations/[station_id]/bikes` page
- drafted RenderParkingPlaceTickets component 
   This component renders the bike of a used parking-place of a station and includes a ticket-pricing-section